### PR TITLE
fix: Fix XREcho instance being destroyed

### DIFF
--- a/Assets/XREcho/Scripts/XREcho.cs
+++ b/Assets/XREcho/Scripts/XREcho.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+[ExecuteInEditMode]
 [RequireComponent(typeof(XREchoConfig))]
 public class XREcho : MonoBehaviour
 {


### PR DESCRIPTION
An error used to appear when using XREcho in edit mode.
![image](https://user-images.githubusercontent.com/20073809/153846905-63c32bda-05f2-4b50-a915-2e6f2b4a2451.png)
This is fixed by setting the XREcho script to also run in edit mode.